### PR TITLE
Add Bearer prefix to frontend apollo client

### DIFF
--- a/packages/api/src/routes/passport.http.ts
+++ b/packages/api/src/routes/passport.http.ts
@@ -79,7 +79,10 @@ class PassportRoutes {
             url: `${process.env.LOGIN_REDIRECT}?token=${token}`,
           });
         } catch (error) {
-          return res.status(500).json(error);
+          return res.status(401).json({
+            error: "Unauthorized",
+            success: false,
+          });
         }
       },
       function (err: any, req: any, res: any) {

--- a/packages/ui/components/login/LoginForm.tsx
+++ b/packages/ui/components/login/LoginForm.tsx
@@ -30,7 +30,7 @@ const LoginForm = (props: Props) => {
         setNetworkError("");
         setSubmitting(true);
         props.perform(values.email, values.password).catch((error) => {
-          setNetworkError(error.message);
+          setNetworkError("Invalid credentials provided");
           setSubmitting(false);
         });
       }}

--- a/packages/ui/pages/_document.tsx
+++ b/packages/ui/pages/_document.tsx
@@ -16,6 +16,10 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@700&display=swap"
             rel="stylesheet"
           />
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+          />
         </Head>
         <body>
           <Main />

--- a/packages/ui/pages/login/success.tsx
+++ b/packages/ui/pages/login/success.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(context) {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
-      Authorization: token,
+      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ query: GET_USER_WITH_ONBOARDING }),
   }).then((r) => r.json());

--- a/packages/ui/services/apollo.ts
+++ b/packages/ui/services/apollo.ts
@@ -27,21 +27,24 @@ const logout = () => {
 
 const errorLink = onError(({ networkError }) => {
   if (networkError && (networkError as ServerParseError).statusCode) {
-    const error = networkError as ServerParseError;
+    const serverError = networkError as ServerParseError;
     if ((networkError as any).result?.errors) {
       let error = (networkError as any).result?.errors[0];
       if (
-        error?.message === "You are not authorized to perform this request."
+        error?.message.includes(
+          "You are not authorized to perform this request."
+        )
       ) {
         logout();
       }
     }
-    if (error.statusCode === 401) {
+    if (serverError.statusCode === 401) {
       logout();
     }
     if (
-      error.message.indexOf("You are not authorized to perform this request.") >
-      -1
+      serverError.message.indexOf(
+        "You are not authorized to perform this request."
+      ) > -1
     ) {
       logout();
     }
@@ -63,7 +66,7 @@ const authLink = new ApolloLink((operation, forward) => {
     return {
       headers: {
         ...headers,
-        authorization: token ?? token,
+        authorization: token ? `Bearer ${token}` : "",
       },
     };
   });


### PR DESCRIPTION
- Adds `Bearer` prefix to Apollo Authorization Header
- Fixes the "Unexpected Token" displayed when bad credentials are provided
- Attempts to fix flash of unstyled content (FOUC) by adding Material Icons to the _document.tsx